### PR TITLE
[megaclisas-status] initialize ldpdcount to avoid error on some systems

### DIFF
--- a/wrapper-scripts/megaclisas-status
+++ b/wrapper-scripts/megaclisas-status
@@ -66,6 +66,7 @@ def returnArrayInfo(output,controllerid,arrayid):
 	id = 'c'+str(controllerid)+'u'+str(arrayid)
 	operationlinennumber = False
 	linenumber = 0
+	ldpdcount = 0
 
 	for line in output:
 		if re.match(r'Number Of Drives\s*((per span))?:.*[0-9]+$',line.strip()):


### PR DESCRIPTION
have same problem as http://hwraid.le-vert.net/ticket/238

but that ticket perhaps doesn't make clear that megaclisas-status doesn't work in the traceback case, this avoids the script crashing and lets me monitor the hard drives.
