### PR TITLE
Handle arrays which don't report a drive count

### DIFF
--- a/wrapper-scripts/megaclisas-status
+++ b/wrapper-scripts/megaclisas-status
@@ -66,6 +66,7 @@ def returnArrayInfo(output,controllerid,arrayid):
 	id = 'c'+str(controllerid)+'u'+str(arrayid)
 	operationlinennumber = False
 	linenumber = 0
+	ldpdcount = 0
 
 	for line in output:
 		if re.match(r'Number Of Drives\s*((per span))?:.*[0-9]+$',line.strip()):


### PR DESCRIPTION
We have a CacheCade virtual disk configured which reports as:

```
ramoth [~] % sudo megacli -LDInfo -l2 -a0 -NoLog

Adapter 0 -- Virtual Drive Information:
CacheCade Virtual Drive: 2 (Target Id: 2)
Virtual Drive Type    : CacheCade 
Name          : 
RAID Level        : Primary-1, Secondary-0
State             : Optimal
Size          : 558.406 GB
Target Id of the Associated LDs : 0,3,1
Default Cache Policy  : WriteBack, ReadAdaptive, Direct, No Write Cache if Bad BBU
Current Cache Policy  : WriteBack, ReadAdaptive, Direct, No Write Cache if Bad BBU

Exit Code: 0x00
```

That currently fails, because there is no drive count, with:

```
ramoth [~] % sudo megaclisas-status 
-- Controller informations --
-- ID | Model
c0 | LSI MegaRAID SAS 9271-8iCC

-- Arrays informations --
-- ID | Type | Size | Status | InProgress
c0u0 | RAID1 | 465G | Optimal | None
c0u1 | RAID6 | 7633G | Optimal | None
Traceback (most recent call last):
  File "/usr/sbin/megaclisas-status", line 164, in <module>
    arrayinfo = returnArrayInfo(output,controllerid,arrayid)
  File "/usr/sbin/megaclisas-status", line 101, in returnArrayInfo
    if ldpdcount and (int(spandepth) > 1):
UnboundLocalError: local variable 'ldpdcount' referenced before assignment
```