### PR TITLE
[sas2ircu-status] Add "Device is a unknown device" as a device delimiter

### DIFF
--- a/wrapper-scripts/sas2ircu-status
+++ b/wrapper-scripts/sas2ircu-status
@@ -95,7 +95,7 @@ def getDiskList(ctrlnmbr):
   slotid=''
   realid=['','']
   for line in res:
-    if re.match('^Device is a Hard disk.*$',line) or re.match('^Device is a Enclosure services device.*$',line):
+    if re.match('^Device is a Hard disk.*$',line) or re.match('^Device is a Enclosure services device.*$',line) or re.match('^Device is a unknown device.*$',line):
       if diskid == -1:
         diskid=diskid+1
       else:


### PR DESCRIPTION
In the output of sas2ircu on my Dell r510, a backplane appears as a "unknown device" after the last disk, and its serial number and other attributes were writing over the actual disk.