### PR TITLE
added arrayindex

### DIFF
--- a/wrapper-scripts/megaclisas-status
+++ b/wrapper-scripts/megaclisas-status
@@ -255,7 +255,7 @@ def returnHBAInfo(table,output,controllerid):
 	if controllermodel != 'Unknown':
 		table.append([ 'c'+str(controllerid), controllermodel, controllerram, str(controllertemp), str(controllerbbu), str('FW: '+controllerrev) ])
 
-def returnArrayInfo(output,controllerid,arrayid):
+def returnArrayInfo(output,controllerid,arrayid,arrayindex):
 	id = 'c'+str(controllerid)+'u'+str(arrayid)
 	operationlinennumber = False
 	linenumber = 0
@@ -331,12 +331,12 @@ def returnArrayInfo(output,controllerid,arrayid):
 	# Compute the RAID level
 	if (int(spandepth) >= 2):
 		raidtype = str('RAID-' + str(raidlvl) + '0')
-		NestedLDTable[controllerid][arrayid] = True
+		NestedLDTable[controllerid][arrayindex] = True
 	else:
 		if(raidlvl == 1):
 			if(diskperspan > 2):
 				raidtype = str('RAID-10')
-				NestedLDTable[controllerid][arrayid] = True
+				NestedLDTable[controllerid][arrayindex] = True
 			else:
 				raidtype = str('RAID-' + str(raidlvl))
 		else:
@@ -350,6 +350,7 @@ def returnArrayInfo(output,controllerid,arrayid):
 
 def returnDiskInfo(output,controllerid):
 	arrayid = False
+	arrayindex = -1
 	sarrayid = 'Unknown'
 	diskid = False
 	oldenclid = False
@@ -385,6 +386,7 @@ def returnDiskInfo(output,controllerid):
 			dsize = re.sub(' \[.*\.*$', '', dsize)
 			dsize = re.sub('[0-9][0-9] GB', ' Gb', dsize)
 		if re.match(r'^Virtual Drive: [0-9]+.*$',line.strip()):
+			arrayindex += 1
 			arrayid = line.split('(')[0].split(':')[1].strip()
 		if re.match(r'PD: [0-9]+ Information.*$',line.strip()):
 			diskid = line.split()[1].strip()
@@ -426,7 +428,7 @@ def returnDiskInfo(output,controllerid):
  					percent = returnRebuildProgress(output)
  					fstate = str('Rebuilding (%d%%)' % (percent))
 
-				if (( NestedLDTable[controllerid][int(arrayid)] == True) and (spanid != False)):
+				if (( NestedLDTable[controllerid][int(arrayindex)] == True) and (spanid != False)):
 					sarrayid = str(arrayid)+"s"+spanid
 				else:
 					sarrayid = str(arrayid)
@@ -564,7 +566,7 @@ if printarray:
 	mlen = 0
 	rlen = 0
 	while controllerid < controllernumber:
-		arrayid = 0
+		arrayindex = 0
 
 		cmd = '%s -LDInfo -lall -a%d -NoLog' % (megaclipath, controllerid)
 		output = getOutput(cmd)
@@ -583,21 +585,21 @@ if printarray:
 					ldcount += 1
 					ldid += 1
 
-		while arrayid < arraynumber:
-			ldid = LDTable[controllerid][arrayid]
+		while arrayindex < arraynumber:
+			ldid = LDTable[controllerid][arrayindex]
 			cmd = '%s -LDInfo -l%d -a%d -NoLog' % (megaclipath, ldid, controllerid)
 			output = getOutput(cmd)
-			arrayinfo = returnArrayInfo(output, controllerid, ldid)
+			arrayinfo = returnArrayInfo(output, controllerid, ldid, arrayindex)
 			if ( len(arrayinfo[4]) > mlen):
 				mlen = len(arrayinfo[4])
 			if ( len(arrayinfo[1]) > rlen):
 				rlen = len(arrayinfo[1])
-			arrayid += 1
+			arrayindex += 1
 		controllerid += 1
 
 	controllerid = 0
 	while controllerid < controllernumber:
-		arrayid = 0
+		arrayindex = 0
 
 		cmd = '%s -AdpGetPciInfo -a%d -NoLog' % (megaclipath, controllerid)
 		output = getOutput(cmd)
@@ -606,11 +608,11 @@ if printarray:
 		cmd = '%s -LDInfo -lall -a%d -NoLog' % (megaclipath, controllerid)
 		output = getOutput(cmd)
 		arraynumber = returnArrayNumber(output)
-		while arrayid < arraynumber:
-			ldid = LDTable[controllerid][arrayid]
+		while arrayindex < arraynumber:
+			ldid = LDTable[controllerid][arrayindex]
 			cmd = '%s -LDInfo -l%d -a%d -NoLog' % (megaclipath, ldid, controllerid)
 			output = getOutput(cmd)
-			arrayinfo = returnArrayInfo(output,controllerid, ldid)
+			arrayinfo = returnArrayInfo(output,controllerid, ldid, arrayindex)
 
 			if pcipath:
 				diskprefix = str('/dev/disk/by-path/pci-' + pcipath + '-scsi-0:')
@@ -643,7 +645,7 @@ if printarray:
 				nagiosbadarray=nagiosbadarray+1
 			else:
 				nagiosgoodarray=nagiosgoodarray+1
-			arrayid += 1
+			arrayindex += 1
 			i += 1
 		controllerid += 1
 	if not nagiosmode:


### PR DESCRIPTION
Made array index (the index of the array in LDTable/NestedLDTable)
separate from the array id, which is read from megacli.

If the machine has nonconsecutive array IDs, or the array IDs don’t
begin at 0, this can cause accessing the arrayid-ith element from
LDTable/NestedLDTable to fail.

Fixes issue #26.