### PR TITLE
Update megaclisas-status

### DIFF
--- a/wrapper-scripts/megaclisas-status
+++ b/wrapper-scripts/megaclisas-status
@@ -39,7 +39,7 @@ def print_usage():
 
 # We need root access to query
 if __name__ == '__main__':
-	if os.getenv('USER') != 'root':
+	if os.getenv('LOGNAME') != 'root':
 		print '# This script requires Administrator privs! e.g :\r'
 		print 'sudo '+str(sys.argv[0])+'\r'
 		sys.exit(5)


### PR DESCRIPTION
Hi,

Allow megaclisas-status to be run in root crontab.

Actually os.getenv('USER') return 'None' in root crontab.