### PR TITLE
3ware-status - Add disk serials to Disks Information output

### DIFF
--- a/wrapper-scripts/3ware-status
+++ b/wrapper-scripts/3ware-status
@@ -122,13 +122,14 @@ if not nagiosmode:
 # List disks
 if not nagiosmode:
     print '-- Disks informations'
-    print '-- ID\tModel\t\t\tStatus'
+    print '-- ID\tModel\t\tSerial\t\tStatus'
 for controller in controllerlist:
     cmd = binarypath+' info '+controller
     output = getOutput(cmd)
     disklist = returnDiskList(output)
     for disk in disklist:
         id = controller+disk[2]+disk[0]
+        serial = disk[6]
         cmd = binarypath+' info '+controller+' '+disk[0]+' model'
         model = getOutput(cmd)[0].split(' = ')[1].strip()
         cmd = binarypath+' info '+controller+' '+disk[0]+' status'
@@ -139,7 +140,7 @@ for controller in controllerlist:
         else:
             nagiosgooddisk=nagiosgooddisk+1
         if not nagiosmode:
-            print id+'\t'+model+'\t'+status
+            print id+'\t'+model+'\t'+serial+'\t'+status
 
 if nagiosmode:
     if bad:


### PR DESCRIPTION
Useful to see a disk serial number in output, so now get output like :

-- Disks informations
-- ID   Model           Serial          Status
c0u0p0  ST3750640AS     3QD0GGM1        OK
c0u0p1  ST3750640AS     3QD027Y9        OK
c0u0p2  ST3750640AS     3QD0L6NP        OK
c0u0p3  ST3750640AS     3QD08MVE        OK
c0u0p4  ST3750640AS     5QD4NS7V        OK
c7u0p0  ST3750640AS     3QD06JG8        OK
c7u0p1  ST3750640AS     3QD08P5S        OK

with a "Serial" column.