### PR TITLE
Add check to see if we have root. Required for sas3ircu binary to work.

### DIFF
--- a/wrapper-scripts/sas2ircu-status
+++ b/wrapper-scripts/sas2ircu-status
@@ -29,6 +29,16 @@ if len(sys.argv) > 1:
 
 bad=False
 
+# We need root access to query
+if __name__ == '__main__':
+	try:
+		root_or_admin = os.geteuid() == 0
+	except AttributeError:
+		root_or_admin = ctypes.windll.shell32.IsUserAnAdmin() !=0
+	if not root_or_admin:
+		print '# This script requires Administrator privileges'
+		sys.exit(5)
+
 # Get command output
 def getOutput(cmd):
   output=os.popen(cmd+' 2>/dev/null')


### PR DESCRIPTION
I would like to request this merge to implement a check for root access with this wrapper script.
We use the script solo (as a standalone check) and it give misleading output without root access:

Without root:
$ /usr/bin/check_sas3ircu 
-- Controller informations --
-- ID | Model

-- Arrays informations --
-- ID | Type | Size | Status

-- Disks informations
-- ID | Model | Status

$ /usr/bin/check_sas3ircu  --nagios
RAID OK - Arrays: OK:0 Bad:0 - Disks: OK:0 Bad:0

$ echo $?
0

As you can see, no controller details, but the check returns exit 0. Also, Arrays and disks are both 0. A quick and easy fix is to add a check for root access. 
