### PR TITLE
[aacraid-status] Fix false non-optimal status when JBOD disks are present

### DIFF
--- a/wrapper-scripts/aacraid-status
+++ b/wrapper-scripts/aacraid-status
@@ -314,7 +314,7 @@ while controllerid <= controllernumber:
     for disk in diskinfo:
 
         # Generic verification no matter is the disk is member of an array or not
-        if disk[1] not in [ 'Online', 'Hot Spare', 'Ready', 'Global Hot-Spare', 'Dedicated Hot-Spare' ]:
+        if disk[1] not in [ 'Online', 'Online (JBOD)', 'Hot Spare', 'Ready', 'Global Hot-Spare', 'Dedicated Hot-Spare' ]:
             bad = True
             nagiosbaddisk += 1
         else:


### PR DESCRIPTION
When disks are added individually as JBOD, they are reported as "Online (JBOD)". aacraid-status currently considers this bad and prints a message that the array is not in an optimal state.