### PR TITLE
Add support of HBA device

### DIFF
--- a/wrapper-scripts/aacraid-status
+++ b/wrapper-scripts/aacraid-status
@@ -314,7 +314,7 @@ while controllerid <= controllernumber:
     for disk in diskinfo:
 
         # Generic verification no matter is the disk is member of an array or not
-        if disk[1] not in [ 'Online', 'Online (JBOD)', 'Hot Spare', 'Ready', 'Global Hot-Spare', 'Dedicated Hot-Spare' ]:
+        if disk[1] not in [ 'Online', 'Online (JBOD)', 'Hot Spare', 'Ready', 'Global Hot-Spare', 'Dedicated Hot-Spare', 'Raw (Pass Through)' ]:
             bad = True
             nagiosbaddisk += 1
         else:


### PR DESCRIPTION
Add support of HBA device (ex: Adaptec HBA 1000 8i)
The patch avoids the last line:
--------8<--------------------------------------------------------------
-- Controller informations --
-- ID | Model | Status
c0 | Adaptec HBA 1000 8i | Optimal

-- Arrays informations --
-- ID | Type | Size | Status | Task | Progress

-- Disks informations
-- ID | Model | Status
c0uXd0 | HGST HUC101860CSS204 03GEJHSC | Raw (Pass Through)
c0uXd1 | HGST HUC101860CSS204 0BV049BH | Raw (Pass Through)
c0uXd2 | HGST HUC101860CSS204 03GG2XVC | Raw (Pass Through)
c0uXd3 | HGST HUC101860CSS204 03GG2ZDC | Raw (Pass Through)

There is at least one disk/array in a NOT OPTIMAL state.
--------8<--------------------------------------------------------------