### PR TITLE
[megaclisas-status] reformat "drive model" in disk info blocks

### DIFF
--- a/wrapper-scripts/megaclisas-status
+++ b/wrapper-scripts/megaclisas-status
@@ -476,6 +476,21 @@ def returnDiskInfo(output,controllerid):
 		elif re.match(r'Inquiry Data: .*$',line.strip()):
 			model = line.split(':')[1].strip()
 			model = re.sub(' +', ' ', model)
+
+			# re-define our "sub-code"
+			# our seagate drives have an ID string of
+			# 'Z1E19S2QST2000DM001-1CH164                      CC43'
+			# or
+			# '6XW02738ST32000542AS                            CC32'
+
+			m = re.match(r'(\w{8})(ST\w+)(?:-(\w{6}))?(?:\s+(\w+))', model)
+			if m:
+			    if m.group(3):
+				model = '{}-{} {} {}'.format(m.group(2), m.group(3), m.group(4), m.group(1))
+			    else:
+				model = '{} {:>10} {}'.format(m.group(2), m.group(4), m.group(1))
+			    continue
+
 			# Sub code
 			manuf = re.sub(' .*', '', model)
 			dtype = re.sub(manuf+' ', '', model)

--- a/wrapper-scripts/megaclisas-status
+++ b/wrapper-scripts/megaclisas-status
@@ -577,6 +577,21 @@ def returnUnconfDiskInfo(output,controllerid):
 		elif re.match(r'Inquiry Data: .*$',line.strip()):
 			model = line.split(':')[1].strip()
 			model = re.sub(' +', ' ', model)
+
+			# re-define our "sub-code"
+			# our seagate drives have an ID string of
+			# 'Z1E19S2QST2000DM001-1CH164                      CC43'
+			# or
+			# '6XW02738ST32000542AS                            CC32'
+
+			m = re.match(r'(\w{8})(ST\w+)(?:-(\w{6}))?(?:\s+(\w+))', model)
+			if m:
+			    if m.group(3):
+				model = '{}-{} {} {}'.format(m.group(2), m.group(3), m.group(4), m.group(1))
+			    else:
+				model = '{} {:>10} {}'.format(m.group(2), m.group(4), m.group(1))
+			    continue
+
 			manuf = re.sub(' .*', '', model)
 			dtype = re.sub(manuf+' ', '', model)
 			dtype = re.sub(' .*', '', dtype)


### PR DESCRIPTION
If the "drive model" looks seagate-ish, reformat it so it's more meaningful.

This:
```
-- Disk information --
-- ID   | Type | Drive Model                     | Size     | Status          | Speed    | Temp | Slot ID  | LSI ID
c0u0p0  | HDD  | Z2408KWYST2000DM001-1CH164 CC43 | 1.818 TB | Online, Spun Up | 6.0Gb/s  | 25C  | [58:1]   | 59
c0u0p1  | HDD  | Z4D07EZ3ST6000DX000-1H217Z CC47 | 5.457 TB | Online, Spun Up | 6.0Gb/s  | 31C  | [58:2]   | 60
c0u0p2  | HDD  | Z1E19S2QST2000DM001-1CH164 CC43 | 1.818 TB | Online, Spun Up | 6.0Gb/s  | 26C  | [58:3]   | 61
c0u0p3  | HDD  | 6XW02738ST32000542AS CC32       | 1.818 TB | Online, Spun Up | 3.0Gb/s  | 25C  | [58:4]   | 62
c0u0p4  | HDD  | Z4D07QPZST6000DX000-1H217Z CC47 | 5.457 TB | Online, Spun Up | 6.0Gb/s  | 30C  | [58:5]   | 63
```
becomes this:
```
-- Disk information --
-- ID   | Type | Drive Model                      | Size     | Status          | Speed    | Temp | Slot ID  | LSI ID
c0u0p0  | HDD  | ST2000DM001-1CH164 CC43 Z2408KWY | 1.818 TB | Online, Spun Up | 6.0Gb/s  | 25C  | [58:1]   | 59
c0u0p1  | HDD  | ST6000DX000-1H217Z CC47 Z4D07EZ3 | 5.457 TB | Online, Spun Up | 6.0Gb/s  | 31C  | [58:2]   | 60
c0u0p2  | HDD  | ST2000DM001-1CH164 CC43 Z1E19S2Q | 1.818 TB | Online, Spun Up | 6.0Gb/s  | 26C  | [58:3]   | 61
c0u0p3  | HDD  | ST32000542AS       CC32 6XW02738 | 1.818 TB | Online, Spun Up | 3.0Gb/s  | 25C  | [58:4]   | 62
```