### PR TITLE
Numeration in format string and spaces to tab

### DIFF
--- a/wrapper-scripts/megaclisas-status
+++ b/wrapper-scripts/megaclisas-status
@@ -485,11 +485,11 @@ def returnDiskInfo(output,controllerid):
 
 			m = re.match(r'(\w{8})(ST\w+)(?:-(\w{6}))?(?:\s+(\w+))', model)
 			if m:
-			    if m.group(3):
-				model = '{}-{} {} {}'.format(m.group(2), m.group(3), m.group(4), m.group(1))
-			    else:
-				model = '{} {:>10} {}'.format(m.group(2), m.group(4), m.group(1))
-			    continue
+				if m.group(3):
+					model = '{0}-{1} {2} {3}'.format(m.group(2), m.group(3), m.group(4), m.group(1))
+				else:
+					model = '{0} {1:>10} {2}'.format(m.group(2), m.group(4), m.group(1))
+				continue
 
 			# Sub code
 			manuf = re.sub(' .*', '', model)
@@ -586,11 +586,11 @@ def returnUnconfDiskInfo(output,controllerid):
 
 			m = re.match(r'(\w{8})(ST\w+)(?:-(\w{6}))?(?:\s+(\w+))', model)
 			if m:
-			    if m.group(3):
-				model = '{}-{} {} {}'.format(m.group(2), m.group(3), m.group(4), m.group(1))
-			    else:
-				model = '{} {:>10} {}'.format(m.group(2), m.group(4), m.group(1))
-			    continue
+				if m.group(3):
+					model = '{0}-{1} {2} {3}'.format(m.group(2), m.group(3), m.group(4), m.group(1))
+				else:
+					model = '{0} {1:>10} {2}'.format(m.group(2), m.group(4), m.group(1))
+				continue
 
 			manuf = re.sub(' .*', '', model)
 			dtype = re.sub(manuf+' ', '', model)


### PR DESCRIPTION
Old python versions can fall in `ValueError` exception with current string format:
```
$ python
Python 2.6.6 (r266:84292, Jun 14 2019, 09:43:27)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-23)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> model = 'Z1Z3XMHGST4000NM0033-9ZM170 GA0A'
>>> m = re.match(r'(\w{8})(ST\w+)(?:-(\w{6}))?(?:\s+(\w+))', model)
>>> '{}-{} {} {}'.format(m.group(2), m.group(3), m.group(4), m.group(1))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: zero length field name in format
>>> m.group(2)
'ST4000NM0033'
>>> m.group(3)
'9ZM170'
>>> m.group(4)
'GA0A'
>>> m.group(1)
'Z1Z3XMHG'
```
Also corrected spaces to tabs.